### PR TITLE
Resort to set amount of http jobs

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,79 +2,65 @@
   "jobs": [
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "http://194.54.14.168:80",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "https://194.54.14.168:443",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "http://5.188.189.254:80",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "https://5.188.189.254:443",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "https://37.18.111.225:443",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "https://37.18.111.226:443",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {
       "type": "http",
+      "count": 10,
       "args": {
         "method": "GET",
         "path": "https://185.157.96.145:443",
-        "interval_ms": 1,
-        "client": {
-          "async": true
-        }
+        "interval_ms": 1
       }
     },
     {


### PR DESCRIPTION
Async mode seems to spawn too many goroutines if target is unresponsive. Use set amount of http jobs instead until this is fixed